### PR TITLE
fix Pop OS check

### DIFF
--- a/imports_manager.py
+++ b/imports_manager.py
@@ -16,7 +16,7 @@ dist = distro.id()
 
 def install_package(package_name):
 
-    if dist == "debian" or dist == "ubuntu":
+    if dist == "debian" or dist == "ubuntu" or dist == "pop":
         cmd = ["sudo", "apt", "install", package_name, "-y"]
     elif dist == "fedora" or dist == "centos" or dist == "rhel":
         cmd = ["sudo", "dnf", "install", package_name, "-y"]


### PR DESCRIPTION
On Pop OS function distro.id returns 'pop'
```
>>> distro.id()
'pop'
```