### PR TITLE
install.sh fixes, new laptop model tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - Run ```install.sh``` from the desktop folder. 
 
 ## Supported Laptop models (tested)
+- MSI GP66 12UGS
 - MSI GP76 11UG
 
 ## Supported Linux Distro (tested)

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ if test -f ~/Desktop/OFC/OFC.py;
 then
     FLAG_3=1
 else
+    REPO_DIR=$(dirname "$(readlink -f "$0")")
     echo "This is a shell script to install all the dependencies required for this software to run."
     echo "Dependencies required are as follows."
     echo "1 -> python3-virtualenv AND python3-venv"
@@ -29,18 +30,34 @@ else
     python3 -m venv ~/Desktop/OFC
     echo "----------Virtual Environment for Open Freeze Center created----------"
     echo "----------Installing PyGObject----------"
-    ~/Desktop/OFC/bin/pip3 install PyGObject
+    # get distro version if ubuntu base, since we need to restrict pygobject version for distro version <24.04
+	RESTRICT_GI_VER=0
+	if [ -f /etc/os-release ]; then
+		. /etc/os-release
+		if [[ $ID == *"ubuntu"* ]] || [[ $ID_LIKE == *"ubuntu"* ]]; then
+		    echo "Running ubuntu-based distro"
+		    if { echo "$VERSION_ID"; echo "22.04.5"; } | sort --version-sort --check=quiet; then
+		        echo "Version is 22.04 or less, restricting pygobject version"
+		        RESTRICT_GI_VER=1
+		    fi
+		fi
+	fi
+    if [ "$RESTRICT_GI_VER" -eq "0" ]; then
+        ~/Desktop/OFC/bin/pip3 install PyGObject
+    else
+        ~/Desktop/OFC/bin/pip3 install "PyGObject<=3.52.0"
+    fi
     echo "----------Installing PyCairo----------"
     ~/Desktop/OFC/bin/pip3 install pycairo
     echo "----------Installing Expert----------"
     sudo apt-get install expect
     echo "----------Moving files to virtual environment----------"
-    cp -i ~/Downloads/OpenFreezeCenter-5/install.sh  ~/Desktop/OFC
-    cp -i ~/Downloads/OpenFreezeCenter-5/file_1.sh  ~/Desktop/OFC
-    cp -i ~/Downloads/OpenFreezeCenter-5/file_2.sh  ~/Desktop/OFC
-    cp -i ~/Downloads/OpenFreezeCenter-5/OFC.py  ~/Desktop/OFC
-    cp -i ~/Downloads/OpenFreezeCenter-5/README.md  ~/Desktop/OFC
-    cp -i ~/Downloads/OpenFreezeCenter-5/LICENSE  ~/Desktop/OFC
+    cp -i "${REPO_DIR}/install.sh" ~/Desktop/OFC
+    cp -i "${REPO_DIR}/file_1.sh" ~/Desktop/OFC
+    cp -i "${REPO_DIR}/file_2.sh" ~/Desktop/OFC
+    cp -i "${REPO_DIR}/OFC.py" ~/Desktop/OFC
+    cp -i "${REPO_DIR}/README.md" ~/Desktop/OFC
+    cp -i "${REPO_DIR}/LICENSE"  ~/Desktop/OFC
     FLAG_3=1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -18,7 +18,7 @@ else
     echo "1 -> python3-virtualenv AND python3-venv"
     echo "2 -> PyGObject" 
     echo "3 -> PyCairo" 
-    echo "4 -> Expert" 
+    echo "4 -> Expect" 
     echo "----------Creating Folder for Open Freeze Center----------"
     cd ~/Desktop
     mkdir OFC
@@ -49,7 +49,7 @@ else
     fi
     echo "----------Installing PyCairo----------"
     ~/Desktop/OFC/bin/pip3 install pycairo
-    echo "----------Installing Expert----------"
+    echo "----------Installing Expect----------"
     sudo apt-get install expect
     echo "----------Moving files to virtual environment----------"
     cp -i "${REPO_DIR}/install.sh" ~/Desktop/OFC


### PR DESCRIPTION
Thanks for this nice little piece of code. I had a couple issues I ran into with the install script that I fixed here:

- When copying the repository files, it assumes that the files live in `~/Downloads/OpenFreezeCenter-5`. Instead I grab the directory of the install script as `$REPO_DIR` variable and use that when running `cp` commands.
- For older Ubuntu distros and its derivatives (e.g. Pop!_OS LTS is still at 22.04), the latest PyGObject from pip is not compatible. I added a check during the PyGObject install to test the distro type/version and hold back PyGObject<3.52.0 if the distro is ubuntu-like and version <24.04.
- Added a new tested laptop model to the readme.
- Fixed typos in install script comments ("expert" --> "expect")